### PR TITLE
Add stats resource for OrganicTweet

### DIFF
--- a/lib/twitter-ads/campaign/organic_tweet.rb
+++ b/lib/twitter-ads/campaign/organic_tweet.rb
@@ -7,6 +7,7 @@ module TwitterAds
 
     include TwitterAds::Analytics
 
+    RESOURCE_STATS       = '/1/stats/accounts/%{account_id}'.freeze # @api private
     RESOURCE_ASYNC_STATS = '/1/stats/jobs/accounts/%{account_id}'.freeze # @api private
   end
 end


### PR DESCRIPTION
Allows synchronous pulling of stats from an `OrganicTweet`.

Thank you for this library!